### PR TITLE
Bullet Damage & Speed Options

### DIFF
--- a/Actors/Monsters/Chaingunners/Sharpshooter.txt
+++ b/Actors/Monsters/Chaingunners/Sharpshooter.txt
@@ -264,7 +264,7 @@ Class PM_SniperBullet : PM_SlugBullet
  {
   Speed 56;
   FastSpeed 70;
-  DamageFunction (random(40,50));
+  DamageFunction (60*pm_bulletdamagefactor);
   DamageType "Sniper";
   Scale 0.85;
   RenderStyle "Add";

--- a/Actors/Monsters/Shotgunners/SlugShotgunner.txt
+++ b/Actors/Monsters/Shotgunners/SlugShotgunner.txt
@@ -287,7 +287,7 @@ Class PM_SlugBullet : PM_BulletTracer
  {
   Speed 35;
   FastSpeed 72;
-  DamageFunction (random(35,45));
+  DamageFunction (50*pm_bulletdamagefactor);
   DamageType "Shotgun";
   Scale 0.85;
   RenderStyle "Add";

--- a/Actors/Monsters/ZProjectiles.txt
+++ b/Actors/Monsters/ZProjectiles.txt
@@ -16,7 +16,12 @@ Class PMProjectileBase : Actor abstract
   RenderStyle "Add";
   Alpha 1.0;
  }
-  
+ 
+  override void PostBeginPlay()
+  {
+   Super.PostBeginPlay();
+   vel*=pm_bulletspeedfactor;
+  }
   override void Tick()
   {
    Super.Tick();
@@ -52,7 +57,7 @@ Class PM_BulletTracer : PMProjectileBase
   Radius 2;
   Speed 36;
   FastSpeed 72;
-  DamageFunction 9;
+  DamageFunction (30*pm_bulletdamagefactor);
   DamageType "Bullet";
   Scale 0.85;
   +BLOODSPLATTER 
@@ -118,7 +123,7 @@ Class PM_RevolverTracer : PM_BulletTracer
 {
 Default
  {
-  DamageFunction 10;
+  DamageFunction (20*pm_bulletdamagefactor);
   DamageType "Revolver";
   Scale 0.75;
  }
@@ -129,7 +134,7 @@ Class PM_DirectorTracer : PM_BulletTracer
 Default
  {
   Speed 70;
-  DamageFunction 10;
+  DamageFunction (120*pm_bulletdamagefactor);
   DamageType "Autocannon";
   Scale 1;
   PMProjectileBase.WhizSound "PM/HeavyBulletWhiz";
@@ -180,7 +185,7 @@ Default
  Radius 2;
  Speed 36;
  FastSpeed 72;
- DamageFunction 7;
+ DamageFunction (15*pm_bulletdamagefactor);
  DamageType "Shotgun";
  Scale 0.85;
 }

--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -1,6 +1,8 @@
 //Monster Behavior and Spawns
 Server Int pm_forgetcheck = 0;
 Server Float projectmalice_fodderdivider = 0.25;
+Server Float pm_bulletdamagefactor = 0.5;
+Server Float pm_bulletspeedfactor = 1;
 
 //HP Slider
 Server Float pm_healthfactor = 1;

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -26,9 +26,19 @@ OptionMenu "projectmalice_options"
 	Slider "Fodder Multiplier:", "projectmalice_fodderdivider", 0.00, 20.00, 0.01, 2
 	StaticText ""
 	StaticText ""
+	StaticText "Bullet Damage Multiplier"
+	StaticText "Change damage multipliers of every bullet."
+	Slider "Damage Multiplier:", "pm_bulletdamagefactor", 0.25, 10, 0.05, 2
+	StaticText ""
+	StaticText ""
+	StaticText "Bullet Speed Multiplier"
+	StaticText "Change speed multipliers of every bullet."
+	Slider "Speed Multiplier:", "pm_bulletspeedfactor", 0.5, 5, 0.05, 2
+	StaticText ""
+	StaticText ""
 	StaticText "Health Multiplier"
 	StaticText "Change health multipliers of every enemy. Save the hassle."
-	Slider "Health Multiplier:", "pm_healthfactor", 1, 10, 0.05, 2
+	Slider "Health Multiplier:", "pm_healthfactor", 0.25, 10, 0.05, 2
 	//Slider "Damage Multiplier:", "pm_damagefactor", 0, 10, 0.10, 2
 	StaticText " "
 	StaticText " "

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -38,7 +38,7 @@ OptionMenu "projectmalice_options"
 	StaticText ""
 	StaticText "Health Multiplier"
 	StaticText "Change health multipliers of every enemy. Save the hassle."
-	Slider "Health Multiplier:", "pm_healthfactor", 0.25, 10, 0.05, 2
+	Slider "Health Multiplier:", "pm_healthfactor", 1, 10, 0.05, 2
 	//Slider "Damage Multiplier:", "pm_damagefactor", 0, 10, 0.10, 2
 	StaticText " "
 	StaticText " "


### PR DESCRIPTION
Added 2 options to the menu:
- Bullet Damage Multiplier
- Bullet Speed Multiplier

~~Additionally, the Health Multiplier has been granted some leeway. The Slider can now go down to 0.25, allowing PM's monsters to spawn with a quarter of their Default Health.~~