### PR TITLE
knockback compensation option

### DIFF
--- a/Actors/Monsters/MonsterBase.txt
+++ b/Actors/Monsters/MonsterBase.txt
@@ -295,6 +295,14 @@ class PMMonsterBase : Actor abstract
 		int(ceil(Default.Health * pm_healthfactor *
 		(SinName != "" ? 
 		CVar.GetCVar("pm_healthfactor_"..SinName).GetFloat() : 1.0)));
+		
+		if(pm_healthfactor_mass)
+		{
+			Mass = 
+			int(ceil(Default.Mass * pm_healthfactor *
+			(SinName != "" ? 
+			CVar.GetCVar("pm_healthfactor_"..SinName).GetFloat() : 1.0)));
+		}
 	}
 
 	override void Tick()

--- a/CVARINFO.txt
+++ b/CVARINFO.txt
@@ -44,6 +44,8 @@ Server Float pm_healthfactor_death = 1;
 Server Float pm_healthfactor_umbral = 1;
 Server Float pm_healthfactor_void = 1;
 
+server bool pm_healthfactor_mass = false;
+
 //Dehacked compat
 server bool projectmalice_dehacked_wolfss_replace = true;
 

--- a/MENUDEF.txt
+++ b/MENUDEF.txt
@@ -157,6 +157,10 @@ OptionMenu "projectmalice_allmultipliersettings"
     StaticText "Health Multiplier"
     StaticText "Change health multipliers of every enemy. Save the hassle."
     Slider "Health Multiplier:", "pm_healthfactor", 1, 10, 0.05, 2
+    StaticText " "
+    StaticText "Decrease damage thrust proportional to health increase."
+    StaticText "Enable if compensating for extremely high-damage weapons."
+	Option "Knockback Compensation", "pm_healthfactor_mass", "OnOff"
     //Slider "Damage Multiplier:", "pm_damagefactor", 0, 10, 0.10, 2
     StaticText " "
     StaticText " "


### PR DESCRIPTION
when enabled enemies' mass is multiplied by their healthfactor, so extremely high-damage weapons won't launch enemies across the room. tested with abyssal marine and all health sliders at 10x